### PR TITLE
docs: add comprehensive bennoo guide

### DIFF
--- a/bennoo_doc/README.md
+++ b/bennoo_doc/README.md
@@ -1,0 +1,20 @@
+# Bennoo Codex Guide
+
+Welcome to the **Bennoo documentation hub** for the OpenAI Codex repository.  
+These documents are designed for new contributors who want to understand the codebase, learn Rust, and begin contributing effectively.
+
+## Document Map
+
+- [Rust Fundamentals](./rust_fundamentals.md) – a crash course on the Rust language with emphasis on patterns used in this repo.
+- [Repository Overview](./repo_overview.md) – explains the layout of the repo and the purpose of each crate or package.
+- [Development Workflow](./development_workflow.md) – how to build, test, format, and submit changes.
+- [Troubleshooting & Issue Handling](./troubleshooting.md) – tips for diagnosing problems and responding to user bug reports.
+
+Each guide assumes minimal prior knowledge. After reading through them you should be able to:
+
+1. Navigate the repository structure.
+2. Understand how Rust ownership, modules, and Cargo work in practice.
+3. Run the CLI and its tests.
+4. Tackle issues and contribute high‑quality pull requests.
+
+Happy hacking!

--- a/bennoo_doc/development_workflow.md
+++ b/bennoo_doc/development_workflow.md
@@ -1,0 +1,118 @@
+# Development Workflow
+
+This guide explains how to build, test, and submit changes to the Codex repository.
+
+## Tooling Overview
+
+- **Rust** ≥ 1.84 is required. A `rust-toolchain.toml` pins the version when using `rustup`.
+- **Cargo** – builds individual crates.
+- **Just** – a command runner with recipes in `codex-rs/justfile` for formatting and linting.
+- **pnpm / Node** – used for formatting markdown and JSON files.
+
+## Setting Up
+
+1. Install [Rustup](https://rustup.rs/) and ensure `cargo` is on your `PATH`.
+2. Install [pnpm](https://pnpm.io/) ≥ 9 if you plan to run formatting scripts.
+3. Clone the repository and enter it:
+   ```bash
+   git clone https://github.com/openai/codex.git
+   cd codex
+   ```
+
+## Building the CLI
+
+The Rust workspace lives in `codex-rs`. To build the primary binary:
+
+```bash
+cd codex-rs
+cargo build -p codex-cli
+```
+
+This produces a `codex` executable under `target/debug/`.
+
+## Formatting and Linting
+
+### Rust
+
+Whenever you edit Rust code:
+
+```bash
+cd codex-rs
+just fmt                    # run rustfmt
+just fix -p <crate>         # run clippy for the crate you touched
+```
+
+`just fix` runs `cargo clippy` with repo-specific lints (see `AGENTS.md`).
+
+### Markdown & JSON
+
+From the repo root:
+
+```bash
+pnpm format
+```
+
+This checks `*.json`, `*.md`, `.github/workflows/*.yml`, and `**/*.js`.  
+For other files, run Prettier manually:
+
+```bash
+pnpm exec prettier --write path/to/file.md
+```
+
+## Running Tests
+
+Run tests for the crate you changed:
+
+```bash
+cd codex-rs
+cargo test -p codex-tui         # example
+```
+
+If you touch shared crates (`common`, `core`, `protocol`), run the full suite:
+
+```bash
+cargo test --all-features
+```
+
+Some tests are skipped automatically in the sandbox environment via `CODEX_SANDBOX` and `CODEX_SANDBOX_NETWORK_DISABLED` variables.
+
+## Commit Guidelines
+
+1. Keep commits focused and provide descriptive messages.
+2. Ensure `git status` is clean before committing.
+3. Do **not** amend or force-push to existing commits when collaborating; instead add new commits or use GitHub’s squash merge.
+
+Example commit workflow:
+
+```bash
+git add path/to/file
+git commit -m "docs: add rust fundamentals guide"
+```
+
+## Submitting a Pull Request
+
+1. Push your branch to GitHub.
+2. Open a PR describing the change and referencing relevant issues.
+3. Run all checks locally before requesting review.
+4. Sign the CLA by commenting `I have read the CLA Document and I hereby sign the CLA` if prompted.
+
+## Local Testing of the CLI
+
+```bash
+cd codex-rs
+cargo run -p codex-cli -- --help
+```
+
+Use `--cd` or `-C` to specify the working directory when launching the CLI.
+
+## Troubleshooting
+
+- Run with verbose logging: `RUST_LOG=debug cargo run -p codex-cli`.
+- If sandbox prevents a command, use `--sandbox danger-full-access` cautiously or run in an isolated container.
+- For snapshot test updates in `tui`:
+  ```bash
+  cargo insta pending-snapshots -p codex-tui
+  cargo insta accept -p codex-tui   # after reviewing
+  ```
+
+Following this workflow ensures consistent, high-quality contributions.

--- a/bennoo_doc/repo_overview.md
+++ b/bennoo_doc/repo_overview.md
@@ -1,0 +1,119 @@
+# Repository Overview
+
+The Codex repository is a monorepo that hosts several tools for running OpenAI's Codex agent locally.  
+It contains both Rust and TypeScript implementations, as well as extensive documentation and tooling.
+
+```
+├── codex-rs/         # Rust workspace with multiple crates
+├── codex-cli/        # Legacy TypeScript CLI
+├── docs/             # User-facing documentation
+├── scripts/          # Maintenance scripts
+├── AGENTS.md         # Instructions for contributors
+├── package.json      # Node-based formatting tooling
+└── ...
+```
+
+## Rust Workspace: `codex-rs`
+
+`codex-rs` is a Cargo workspace containing the core implementation of the CLI and supporting libraries.
+Below is a tour of the main crates:
+
+### `ansi-escape`
+
+Converts ANSI escape sequences into structures that can be rendered with [`ratatui`](https://ratatui.rs/). Used by the TUI to display colored output.
+
+### `apply-patch`
+
+Implements the `apply_patch` utility used by the agent to apply unified diff patches to the workspace. Exposes a library and a small binary for testing.
+
+### `arg0`
+
+Provides helpers for manipulating the program name (`argv[0]`). This allows the CLI to impersonate subcommands like `apply_patch` or sandbox wrappers.
+
+### `chatgpt`
+
+Contains code that interfaces with first‑party ChatGPT APIs. External contributors should coordinate with maintainers before modifying this crate.
+
+### `cli`
+
+The top‑level binary that end users invoke as `codex`. It wires together all other crates and exposes subcommands such as the TUI, `exec`, and the MCP server.
+
+### `common`
+
+Holds utilities shared across crates. Optional features enable CLI argument parsing, elapsed‑time reporting, and sandbox summaries.
+
+### `core`
+
+Business logic for Codex: task planning, tool invocation, sandbox awareness, and project documentation handling. Other crates depend heavily on `codex-core`.
+
+### `exec`
+
+A non‑interactive "headless" mode that runs a prompt to completion, suitable for scripting or CI usage.
+
+### `execpolicy`
+
+Evaluates sandbox policies written in [Starlark](https://github.com/bazelbuild/starlark) to restrict what commands Codex can run. Produces a binary and library.
+
+### `file-search`
+
+Provides fuzzy file searching used by the TUI via the `@` prompt shortcut.
+
+### `linux-sandbox`
+
+Implements Linux sandboxing (Landlock + seccomp). Exposes a CLI for debugging sandbox policies and a library used by `arg0` and other crates.
+
+### `login`
+
+Handles authentication flows for ChatGPT login and API key management. Includes a tiny HTTP server to receive callbacks.
+
+### `mcp-client`
+
+Model Context Protocol client implementation. Manages RPC‑style communication with external MCP servers.
+
+### `mcp-server`
+
+Allows Codex itself to act as an MCP server, exposing tools and information to other agents.
+
+### `mcp-types`
+
+Shared type definitions for the MCP protocol. Also generates TypeScript bindings via the `ts-rs` crate.
+
+### `ollama`
+
+Optional support for the [Ollama](https://ollama.com) local model runner. Streams responses and handles REST requests.
+
+### `protocol`
+
+Defines the Codex wire protocol and conversions between internal structures and MCP types. Uses `uuid`, `base64`, and `ts-rs` for cross‑language compatibility.
+
+### `protocol-ts`
+
+Command‑line tool and library for exporting protocol types to TypeScript. Ensures sync between the Rust and JS ecosystems.
+
+### `tui`
+
+The interactive terminal UI built with `ratatui`. Handles chat rendering, file views, diffing, and user input. Includes snapshot tests using `insta`.
+
+## Legacy TypeScript CLI: `codex-cli`
+
+The `codex-cli` folder hosts the older Node/TypeScript implementation. It remains for historical reference and packaging scripts but is superseded by the Rust CLI. Most new development happens in `codex-rs`.
+
+## Documentation: `docs`
+
+Markdown files that describe how to use Codex:
+
+- installation guides
+- configuration reference
+- sandboxing and authentication docs
+- advanced topics and FAQ
+
+These documents are published as part of the open‑source project and are useful when responding to user questions.
+
+## Other Top‑Level Files
+
+- `PNPM.md`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` configure Node tooling used for formatting.
+- `CHANGELOG.md` tracks notable updates.
+- `cliff.toml` and `scripts/` provide release tooling.
+- `AGENTS.md` defines repository‑wide contributor instructions that you are reading now.
+
+Understanding this layout will help you find the right crate or script when fixing bugs or adding features.

--- a/bennoo_doc/rust_fundamentals.md
+++ b/bennoo_doc/rust_fundamentals.md
@@ -1,0 +1,142 @@
+# Rust Fundamentals
+
+This guide provides the essential Rust concepts needed to understand and contribute to the Codex codebase.  
+For a deeper dive, consult the [official Rust Book](https://doc.rust-lang.org/book/).
+
+## Language Basics
+
+### Variables and Mutability
+
+```rust
+let x = 5;        // immutable
+let mut y = 6;    // mutable
+```
+
+Rust defaults to immutability, encouraging safer code. Use `mut` only when necessary.
+
+### Primitive Types
+
+Rust offers familiar primitives (integers, floats, booleans, chars) and compound types:
+
+```rust
+let tup: (i32, f64, bool) = (1, 2.0, true);
+let arr: [u8; 3] = [1, 2, 3];
+```
+
+### Control Flow
+
+`if`, `loop`, `while`, and `for` operate as in other languages. The final expression in a block is returned implicitly:
+
+```rust
+let result = if condition { 10 } else { 20 };
+```
+
+## Ownership, Borrowing, and Lifetimes
+
+These concepts prevent data races and dangling pointers at compile time.
+
+- **Ownership**: Each value in Rust has a single owner. When the owner goes out of scope, the value is dropped.
+- **Borrowing**: References allow using a value without taking ownership. Mutable (`&mut T`) and immutable (`&T`) borrows are tracked so that only one mutable borrow or many immutable borrows exist at a time.
+- **Lifetimes**: The compiler ensures references remain valid. Most lifetimes are inferred, but explicit annotations (`<'a>`) appear in complex code.
+
+Example:
+
+```rust
+fn greet(name: &str) {
+    println!("Hello {name}!");
+}
+```
+
+`name` is borrowed immutably, so the caller keeps ownership.
+
+## Modules and Crates
+
+- A **crate** is a compilation unit (library or binary). The workspace in `codex-rs` contains multiple crates, each under its own directory.
+- A **module** (`mod`) organizes code within a crate. Files correspond to modules.
+- Use `use` statements to bring items into scope.
+
+```rust
+pub mod utils {
+    pub fn add(a: i32, b: i32) -> i32 { a + b }
+}
+
+use utils::add;
+```
+
+## Cargo
+
+Cargo is Rust’s build system and package manager.
+
+Key commands:
+
+- `cargo build` – compile the crate.
+- `cargo test` – run tests.
+- `cargo run` – build and execute a binary crate.
+- `cargo fmt` – format code (delegated to `rustfmt`).
+
+In this repository, `just` scripts wrap common `cargo` tasks. See [Development Workflow](./development_workflow.md) for details.
+
+## Error Handling
+
+Rust distinguishes between recoverable (`Result<T, E>`) and unrecoverable errors (`panic!`). Codex code tends to use the [`anyhow`](https://docs.rs/anyhow) crate for ergonomic error propagation:
+
+```rust
+use anyhow::{Result, Context};
+
+fn load() -> Result<String> {
+    std::fs::read_to_string("config.toml").context("reading config")
+}
+```
+
+## Traits and Generics
+
+Traits define shared behavior. Generics allow implementations for multiple types:
+
+```rust
+trait Displayable {
+    fn display(&self);
+}
+
+impl<T: std::fmt::Debug> Displayable for T {
+    fn display(&self) {
+        println!("{:?}", self);
+    }
+}
+```
+
+## Asynchronous Programming
+
+Codex relies heavily on async code via `tokio`:
+
+```rust
+use tokio::task;
+
+#[tokio::main]
+async fn main() {
+    let handle = task::spawn(async { 42 });
+    println!("{}", handle.await.unwrap());
+}
+```
+
+Async functions return `Future`s that are polled to completion by an executor.
+
+## Macros
+
+Macros like `println!` or `format!` generate code at compile time. Use `format!("Hello {name}")` to inline variables directly, as required by repo guidelines.
+
+## Testing
+
+Unit tests live in `tests` modules or the `tests/` directory. Snapshot tests use the [`insta`](https://insta.rs) crate, especially in `tui`. Run tests with:
+
+```bash
+cargo test -p codex-tui           # specific crate
+cargo test --all-features         # workspace-wide (for shared crates)
+```
+
+## Further Reading
+
+- [Rust By Example](https://doc.rust-lang.org/rust-by-example/)
+- [Tokio Guide](https://tokio.rs/tokio/tutorial)
+- [Clippy Lints](https://rust-lang.github.io/rust-clippy/) – enforced via `just fix`
+
+Mastering these fundamentals will make navigating the Codex codebase much easier.

--- a/bennoo_doc/troubleshooting.md
+++ b/bennoo_doc/troubleshooting.md
@@ -1,0 +1,59 @@
+# Troubleshooting & Issue Handling
+
+When users report problems or you encounter failing tests, follow these steps to diagnose and resolve the issue.
+
+## Reproducing Problems
+
+1. **Gather context** – confirm the OS, CLI version, and steps to reproduce. Ask users for command output or logs.
+2. **Isolate the environment** – run inside a clean container or using `--sandbox danger-full-access` only if necessary.
+3. **Use verbose logging** – set `RUST_LOG=debug` and collect the output.
+
+## Reading Logs
+
+Logs use the [`tracing`](https://docs.rs/tracing) crate. Common levels:
+
+- `error` – serious failures
+- `warn` – unexpected but recoverable issues
+- `info` – high-level progress
+- `debug`/`trace` – detailed diagnostics
+
+## Common Issues
+
+### Authentication Failures
+
+- Ensure the user has a valid ChatGPT session or API key.
+- For browser-based login, check that the callback URL is whitelisted.
+
+### Sandbox Errors
+
+- Commands may be denied by the sandbox policy. Advise using a less restrictive policy (`--sandbox workspace-write` or `--sandbox danger-full-access`) only in trusted environments.
+- For Linux landlock errors, ensure the `codex-linux-sandbox` binary is installed and executable.
+
+### Patch Application Problems
+
+- Patches are applied with the `codex-apply-patch` crate. Confirm that diff headers and paths are correct.
+- Use `codex debug apply-patch` to test problematic diffs.
+
+### TUI Rendering Glitches
+
+- Snapshot tests in `codex-rs/tui/tests/` help reproduce rendering bugs. Run `cargo test -p codex-tui` and review `.snap` files.
+- Terminal compatibility issues may stem from missing Unicode or color support.
+
+## Debugging Strategies
+
+- Add temporary `tracing::info!` calls to narrow down logic errors.
+- Use `cargo run -p <crate> -- <args>` to execute binaries directly.
+- Write small integration tests under `tests/` to capture regressions.
+
+## Handling User Issues
+
+1. Reproduce the problem locally.
+2. Check open issues or discussions to avoid duplicates.
+3. Provide clear reproduction steps and propose a fix or workaround.
+4. Link relevant documentation (e.g., files under `docs/`).
+
+## Reporting Security Concerns
+
+If an issue might expose a security vulnerability, follow the repository’s security policy and contact `security@openai.com` rather than opening a public issue.
+
+Being systematic and communicative helps maintainers resolve issues quickly and keeps the community healthy.


### PR DESCRIPTION
## Summary
- add `bennoo_doc` with high-level guides for Rust and repo structure
- document development workflow and troubleshooting

## Testing
- `pnpm format` *(fails: AGENTS.md, README.md style issues)*
- `pnpm exec prettier --check "bennoo_doc/*.md"`


------
https://chatgpt.com/codex/tasks/task_e_68c29947fd44832e8da4dbf21406d341